### PR TITLE
Correcting links

### DIFF
--- a/blog/2013/08/26/astroship-for-android-released/index.html
+++ b/blog/2013/08/26/astroship-for-android-released/index.html
@@ -130,7 +130,7 @@
 
 <div class="entry-content"><p>We are proud to present our first Reverse Game for Android, available right now to download for free from the Google Play store.</p>
 
-<p>Find more information on the <a href="http://www.coconauts.net/web/?page_id=19">project page</a>,
+<p>Find more information on the <a href="http://coconauts.net/web/?page_id=19">project page</a>,
 or on the <a href="https://play.google.com/store/apps/details?id=net.coconauts.reverse.asteroids">Google Play page</a>.</p>
 
 <h2>Update (2014-05-01)</h2>

--- a/blog/2014/03/05/watchduino-entered-on-biicontest-2014/index.html
+++ b/blog/2014/03/05/watchduino-entered-on-biicontest-2014/index.html
@@ -128,7 +128,7 @@
   </header>
 
 
-<div class="entry-content"><p>We’ve entered <a href="http://www.coconauts.net/web/?page_id=112">WatchDuino</a> into the <a href="https://www.biicode.com/biicontest2014-en">Arduino/Raspberry Pi competition</a>
+<div class="entry-content"><p>We’ve entered <a href="http://coconauts.net/web/?page_id=112">WatchDuino</a> into the <a href="https://www.biicode.com/biicontest2014-en">Arduino/Raspberry Pi competition</a>
 that the folks at Biicode have set up. We expect it to be a good opportunity to give the project some visibility,
 as well as a good excuse to give the development a little push.
 We hope that our development efforts for the project will make it more reusable and easy to play with.</p>

--- a/blog/2014/10/17/arduino-radio-improvements-low-consumption/index.html
+++ b/blog/2014/10/17/arduino-radio-improvements-low-consumption/index.html
@@ -128,7 +128,7 @@
   </header>
 
 
-<div class="entry-content"><p>In our previous post about how to <a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
+<div class="entry-content"><p>In our previous post about how to <a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
 we explained the basics of the Arduino-Raspberry Pi comunication and we shared a simple code.</p>
 
 <p>But there is more, with a mix of hardware and software, we managed to reduce its power

--- a/blog/2014/12/31/coconauts-2014-retrospective/index.html
+++ b/blog/2014/12/31/coconauts-2014-retrospective/index.html
@@ -138,23 +138,23 @@ at the end of 2015 we have something to compare against.</p>
 
 
 <ul>
-<li>We <a href="http://www.coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
-We are also <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
+<li>We <a href="http://coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
+We are also <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
 so we&rsquo;ll have some more work for next year.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
+<li>We <a href="http://coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
 and we started blogging regularly on it.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
+<li>We <a href="http://coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
 our second LibGDX game for Android. We also did a couple of seasonal updates for it.</li>
 <li>You may have missed it, because we didn&rsquo;t blog about it, but we released a
-<a href="http://www.coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
+<a href="http://coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
 (written in node.js).</li>
 <li>We opened a <a href="https://github.com/coconauts">Github account</a>, where we will
 place all new pieces of public code from now on.</li>
-<li>Minor projects we&rsquo;ve shown you include a <a href="http://www.coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
-<a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
-and a <a href="http://www.coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
+<li>Minor projects we&rsquo;ve shown you include a <a href="http://coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
+<a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
+and a <a href="http://coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
 <li>Internally, we have a much better organization and logistics. We started
-using <a href="http://trello.com">Trello</a> for task management, and <a href="http://www.coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
+using <a href="http://trello.com">Trello</a> for task management, and <a href="http://coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
 automated operations</a>.</li>
 <li>We&rsquo;ve also started a bunch of new projects, but they are still on a very early
 stage, so we haven&rsquo;t shown anything about them yet. Hopefully some of them

--- a/blog/2015/02/26/watchduino2-first-prototype/index.html
+++ b/blog/2015/02/26/watchduino2-first-prototype/index.html
@@ -148,7 +148,7 @@ and I would like to share with you my impressions, its current features and its 
 <h2>Hardware</h2>
 
 <p>We need to talk about new hardware for Watchduino 2,
-as it is very different from its <a href="http://www.coconauts.net/projects/watchduino/">first version</a>
+as it is very different from its <a href="http://coconauts.net/projects/watchduino/">first version</a>
 which makes this new version smaller, prettier and more useful.</p>
 
 <ul>
@@ -167,7 +167,7 @@ which makes this new version smaller, prettier and more useful.</p>
 <h2>Features</h2>
 
 <p>Thanks to this new hardware, we managed to add new features to this new version.
-Most of them were mentioned in the <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
+Most of them were mentioned in the <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
 but you can have another look here:</p>
 
 <h3>Companion app (Android)</h3>

--- a/blog/2015/03/21/exploding-bunnies/index.html
+++ b/blog/2015/03/21/exploding-bunnies/index.html
@@ -130,7 +130,7 @@
 
 
 <div class="entry-content"><p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,

--- a/blog/2015/04/19/creating-trve-chiptune-with-a-tracker/index.html
+++ b/blog/2015/04/19/creating-trve-chiptune-with-a-tracker/index.html
@@ -133,7 +133,7 @@ CHIPTUNE that in the &hellip;">
 
 
 <div class="entry-content"><p>Following up with the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
 remember what I said about those purists only considering to be TRVE
 CHIPTUNE that in the format of Amiga MOD files created with an old
 school tracker software? Well, guess what, you can do just that to
@@ -176,7 +176,7 @@ of tutorials and documentation about all things chiptune and tracking.</li>
 
 
 <p>Don&rsquo;t forget though that there&rsquo;s a saner way to do it, we&rsquo;ve shown you how in the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
 </div>
 
 

--- a/blog/2015/05/18/why-you-should-not-use-arduino-uno/index.html
+++ b/blog/2015/05/18/why-you-should-not-use-arduino-uno/index.html
@@ -188,9 +188,9 @@ easily find compatible clonic boards on Amazon, Ebay or Aliexpress,
 at a fraction of the price.</p>
 
 <p>You could also use a bare ATMega328 like we did in our
-<a href="https://www.coconauts.net/projects/watchduino/">first Watchduino</a>
+<a href="https://coconauts.net/projects/watchduino/">first Watchduino</a>
 or in our
-<a href="https://www.coconauts.net/blog/2014/10/18/arduino-radio-improvements-low-consumption/">light sensor with RF24 radio module</a>.</p>
+<a href="https://coconauts.net/blog/2014/10/18/arduino-radio-improvements-low-consumption/">light sensor with RF24 radio module</a>.</p>
 
 <h2>Arduino UNO is big</h2>
 
@@ -239,7 +239,7 @@ will vary.</p>
 <p>Because it&rsquo;s big, and has a very high consumption, you shouldn&rsquo;t
 ever use it in a prototype, like a remote controlled device, or a
 batery-powered-sensor, or a
- <a href="https://www.coconauts.net/projects/watchduino2/">smartwatch</a>.</p>
+ <a href="https://coconauts.net/projects/watchduino2/">smartwatch</a>.</p>
 
 <p>Also, you probably don&rsquo;t want to develop in a hardware that won&rsquo;t
 match the final product specs, do you ?</p>

--- a/blog/2015/07/06/easily-create-8-bit-sound-effects/index.html
+++ b/blog/2015/07/06/easily-create-8-bit-sound-effects/index.html
@@ -131,7 +131,7 @@ which you might want to use in a game. But of course, if you are having
   </header>
 
 
-<div class="entry-content"><p>In a past post we&rsquo;ve shown you <a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
+<div class="entry-content"><p>In a past post we&rsquo;ve shown you <a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
 which you might want to use in a game. But of course, if you are having
 8-bit music, you&rsquo;ll want your game sound effects to match as well.</p>
 

--- a/blog/2015/08/24/watchduino-2-is-semifinalist-on-the-2015-hackaday-prize/index.html
+++ b/blog/2015/08/24/watchduino-2-is-semifinalist-on-the-2015-hackaday-prize/index.html
@@ -131,7 +131,7 @@
 
 <div class="entry-content"><p><img src="/images/posts/hackaday_semifinal.png" /></p>
 
-<p>We are really excited to announce that <a href="https://www.coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
+<p>We are really excited to announce that <a href="https://coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
 <a href="http://hackaday.com/2015/08/24/100-semifinalists-for-the-2015-hackaday-prize/">the semi-finals of the 2015 edition of the Hackaday Prize</a>!
 It was selected amongst the best 100 of a total of more than 900 projects.
 To see this kind of recognition out of a community that we admire is

--- a/blog/categories/general/atom.xml
+++ b/blog/categories/general/atom.xml
@@ -179,23 +179,23 @@ at the end of 2015 we have something to compare against.</p>
 
 
 <ul>
-<li>We <a href="http://www.coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
-We are also <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
+<li>We <a href="http://coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
+We are also <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
 so we&rsquo;ll have some more work for next year.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
+<li>We <a href="http://coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
 and we started blogging regularly on it.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
+<li>We <a href="http://coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
 our second LibGDX game for Android. We also did a couple of seasonal updates for it.</li>
 <li>You may have missed it, because we didn&rsquo;t blog about it, but we released a
-<a href="http://www.coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
+<a href="http://coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
 (written in node.js).</li>
 <li>We opened a <a href="https://github.com/coconauts">Github account</a>, where we will
 place all new pieces of public code from now on.</li>
-<li>Minor projects we&rsquo;ve shown you include a <a href="http://www.coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
-<a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
-and a <a href="http://www.coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
+<li>Minor projects we&rsquo;ve shown you include a <a href="http://coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
+<a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
+and a <a href="http://coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
 <li>Internally, we have a much better organization and logistics. We started
-using <a href="http://trello.com">Trello</a> for task management, and <a href="http://www.coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
+using <a href="http://trello.com">Trello</a> for task management, and <a href="http://coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
 automated operations</a>.</li>
 <li>We&rsquo;ve also started a bunch of new projects, but they are still on a very early
 stage, so we haven&rsquo;t shown anything about them yet. Hopefully some of them

--- a/blog/page/11/index.html
+++ b/blog/page/11/index.html
@@ -132,7 +132,7 @@ we explained the basics of the Arduino-Raspberry Pi &hellip;">
   </header>
 
 
-  <div class="entry-content"><p>In our previous post about how to <a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
+  <div class="entry-content"><p>In our previous post about how to <a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
 we explained the basics of the Arduino-Raspberry Pi comunication and we shared a simple code.</p>
 
 <p>But there is more, with a mix of hardware and software, we managed to reduce its power

--- a/blog/page/13/index.html
+++ b/blog/page/13/index.html
@@ -313,7 +313,7 @@ More updates on this soon!</p>
   </header>
 
 
-  <div class="entry-content"><p>We’ve entered <a href="http://www.coconauts.net/web/?page_id=112">WatchDuino</a> into the <a href="https://www.biicode.com/biicontest2014-en">Arduino/Raspberry Pi competition</a>
+  <div class="entry-content"><p>We’ve entered <a href="http://coconauts.net/web/?page_id=112">WatchDuino</a> into the <a href="https://www.biicode.com/biicontest2014-en">Arduino/Raspberry Pi competition</a>
 that the folks at Biicode have set up. We expect it to be a good opportunity to give the project some visibility,
 as well as a good excuse to give the development a little push.
 We hope that our development efforts for the project will make it more reusable and easy to play with.</p>

--- a/blog/page/14/index.html
+++ b/blog/page/14/index.html
@@ -133,7 +133,7 @@
 
   <div class="entry-content"><p>We are proud to present our first Reverse Game for Android, available right now to download for free from the Google Play store.</p>
 
-<p>Find more information on the <a href="http://www.coconauts.net/web/?page_id=19">project page</a>,
+<p>Find more information on the <a href="http://coconauts.net/web/?page_id=19">project page</a>,
 or on the <a href="https://play.google.com/store/apps/details?id=net.coconauts.reverse.asteroids">Google Play page</a>.</p>
 
 <h2>Update (2014-05-01)</h2>

--- a/blog/page/7/index.html
+++ b/blog/page/7/index.html
@@ -182,7 +182,7 @@ And we ended up with a nice solution that you can easily replicate in your own b
 
   <div class="entry-content"><p><img src="/images/posts/hackaday_semifinal.png" /></p>
 
-<p>We are really excited to announce that <a href="https://www.coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
+<p>We are really excited to announce that <a href="https://coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
 <a href="http://hackaday.com/2015/08/24/100-semifinalists-for-the-2015-hackaday-prize/">the semi-finals of the 2015 edition of the Hackaday Prize</a>!
 It was selected amongst the best 100 of a total of more than 900 projects.
 To see this kind of recognition out of a community that we admire is

--- a/blog/page/8/index.html
+++ b/blog/page/8/index.html
@@ -133,7 +133,7 @@ which you might want to use in a game. But of course, if you are having
   </header>
 
 
-  <div class="entry-content"><p>In a past post we&rsquo;ve shown you <a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
+  <div class="entry-content"><p>In a past post we&rsquo;ve shown you <a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
 which you might want to use in a game. But of course, if you are having
 8-bit music, you&rsquo;ll want your game sound effects to match as well.</p>
 
@@ -337,7 +337,7 @@ but we should take advantage of technology and let machines water our plants for
 
 
   <div class="entry-content"><p>Following up with the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
 remember what I said about those purists only considering to be TRVE
 CHIPTUNE that in the format of Amiga MOD files created with an old
 school tracker software? Well, guess what, you can do just that to

--- a/blog/page/9/index.html
+++ b/blog/page/9/index.html
@@ -135,7 +135,7 @@ time, we&rsquo;ve been closely following it&rsquo;s reception, and &hellip;">
 
 
   <div class="entry-content"><p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,

--- a/blog/tags/android/atom.xml
+++ b/blog/tags/android/atom.xml
@@ -124,7 +124,7 @@ possible to port this plugin to IOS. But feel free to contribute to our project 
 <updated>2015-03-21T15:53:19+00:00</updated>
 <id>http://coconauts.net/blog/2015/03/21/exploding-bunnies</id>
 <content type="html"><![CDATA[<p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,
@@ -224,7 +224,7 @@ and I would like to share with you my impressions, its current features and its 
 <h2>Hardware</h2>
 
 <p>We need to talk about new hardware for Watchduino 2,
-as it is very different from its <a href="http://www.coconauts.net/projects/watchduino/">first version</a>
+as it is very different from its <a href="http://coconauts.net/projects/watchduino/">first version</a>
 which makes this new version smaller, prettier and more useful.</p>
 
 <ul>
@@ -243,7 +243,7 @@ which makes this new version smaller, prettier and more useful.</p>
 <h2>Features</h2>
 
 <p>Thanks to this new hardware, we managed to add new features to this new version.
-Most of them were mentioned in the <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
+Most of them were mentioned in the <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
 but you can have another look here:</p>
 
 <h3>Companion app (Android)</h3>

--- a/blog/tags/arduino/atom.xml
+++ b/blog/tags/arduino/atom.xml
@@ -341,7 +341,7 @@ Watchduino development!</p>
 <id>http://coconauts.net/blog/2015/08/24/watchduino-2-is-semifinalist-on-the-2015-hackaday-prize</id>
 <content type="html"><![CDATA[<p><img src="http://coconauts.net/images/posts/hackaday_semifinal.png" /></p>
 
-<p>We are really excited to announce that <a href="https://www.coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
+<p>We are really excited to announce that <a href="https://coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
 <a href="http://hackaday.com/2015/08/24/100-semifinalists-for-the-2015-hackaday-prize/">the semi-finals of the 2015 edition of the Hackaday Prize</a>!
 It was selected amongst the best 100 of a total of more than 900 projects.
 To see this kind of recognition out of a community that we admire is

--- a/blog/tags/astroship/atom.xml
+++ b/blog/tags/astroship/atom.xml
@@ -18,7 +18,7 @@
 <id>http://coconauts.net/blog/2013/08/26/astroship-for-android-released</id>
 <content type="html"><![CDATA[<p>We are proud to present our first Reverse Game for Android, available right now to download for free from the Google Play store.</p>
 
-<p>Find more information on the <a href="http://www.coconauts.net/web/?page_id=19">project page</a>,
+<p>Find more information on the <a href="http://coconauts.net/web/?page_id=19">project page</a>,
 or on the <a href="https://play.google.com/store/apps/details?id=net.coconauts.reverse.asteroids">Google Play page</a>.</p>
 
 <h2>Update (2014-05-01)</h2>

--- a/blog/tags/chiptune/atom.xml
+++ b/blog/tags/chiptune/atom.xml
@@ -16,7 +16,7 @@
 <link href="http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects/"/>
 <updated>2015-07-06T20:10:17+00:00</updated>
 <id>http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects</id>
-<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
+<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
 which you might want to use in a game. But of course, if you are having
 8-bit music, you&rsquo;ll want your game sound effects to match as well.</p>
 
@@ -73,7 +73,7 @@ development.</p>
 <updated>2015-04-19T19:34:31+00:00</updated>
 <id>http://coconauts.net/blog/2015/04/19/creating-trve-chiptune-with-a-tracker</id>
 <content type="html"><![CDATA[<p>Following up with the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
 remember what I said about those purists only considering to be TRVE
 CHIPTUNE that in the format of Amiga MOD files created with an old
 school tracker software? Well, guess what, you can do just that to
@@ -116,7 +116,7 @@ of tutorials and documentation about all things chiptune and tracking.</li>
 
 
 <p>Don&rsquo;t forget though that there&rsquo;s a saner way to do it, we&rsquo;ve shown you how in the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
 ]]></content>
 </entry>
 

--- a/blog/tags/coconauts/atom.xml
+++ b/blog/tags/coconauts/atom.xml
@@ -247,23 +247,23 @@ at the end of 2015 we have something to compare against.</p>
 
 
 <ul>
-<li>We <a href="http://www.coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
-We are also <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
+<li>We <a href="http://coconauts.net/blog/2014/04/30/watchduino-awarded-first-price-at-biicontest-2014/">won the Biicode 2014 competition with Watchduino</a>.
+We are also <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">working on an improved version</a>,
 so we&rsquo;ll have some more work for next year.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
+<li>We <a href="http://coconauts.net/blog/2014/05/10/coconauts-is-powered-by-octopress/">migrated our blog from Wordpress to Octopress</a>,
 and we started blogging regularly on it.</li>
-<li>We <a href="http://www.coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
+<li>We <a href="http://coconauts.net/blog/2014/09/15/super-time-bomb-is-out/">released Super Time Bomb</a>,
 our second LibGDX game for Android. We also did a couple of seasonal updates for it.</li>
 <li>You may have missed it, because we didn&rsquo;t blog about it, but we released a
-<a href="http://www.coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
+<a href="http://coconauts.net/projects/game-manager/">Web Game Manager</a> desktop app
 (written in node.js).</li>
 <li>We opened a <a href="https://github.com/coconauts">Github account</a>, where we will
 place all new pieces of public code from now on.</li>
-<li>Minor projects we&rsquo;ve shown you include a <a href="http://www.coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
-<a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
-and a <a href="http://www.coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
+<li>Minor projects we&rsquo;ve shown you include a <a href="http://coconauts.net/blog/2014/08/02/web-screensaver/">Chromium based screensaver</a>,
+<a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">wireless radio Arduino sensors</a>,
+and a <a href="http://coconauts.net/blog/2014/08/14/meteorological-station-with-rasbperry-pi-phase-1/">meteorological station powered by a Raspberry Pi</a>.</li>
 <li>Internally, we have a much better organization and logistics. We started
-using <a href="http://trello.com">Trello</a> for task management, and <a href="http://www.coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
+using <a href="http://trello.com">Trello</a> for task management, and <a href="http://coconauts.net/blog/2014/09/09/background-tasks-in-jenkins-ipchange/">Jenkins and Ansible for
 automated operations</a>.</li>
 <li>We&rsquo;ve also started a bunch of new projects, but they are still on a very early
 stage, so we haven&rsquo;t shown anything about them yet. Hopefully some of them

--- a/blog/tags/game/atom.xml
+++ b/blog/tags/game/atom.xml
@@ -109,7 +109,7 @@ The bottleneck is the number of details and shadows in the scene, or drawCalls i
 <updated>2015-03-21T15:53:19+00:00</updated>
 <id>http://coconauts.net/blog/2015/03/21/exploding-bunnies</id>
 <content type="html"><![CDATA[<p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,
@@ -192,7 +192,7 @@ comment, and we&rsquo;ll try to make the next iteration even better.</p>
 <id>http://coconauts.net/blog/2013/08/26/astroship-for-android-released</id>
 <content type="html"><![CDATA[<p>We are proud to present our first Reverse Game for Android, available right now to download for free from the Google Play store.</p>
 
-<p>Find more information on the <a href="http://www.coconauts.net/web/?page_id=19">project page</a>,
+<p>Find more information on the <a href="http://coconauts.net/web/?page_id=19">project page</a>,
 or on the <a href="https://play.google.com/store/apps/details?id=net.coconauts.reverse.asteroids">Google Play page</a>.</p>
 
 <h2>Update (2014-05-01)</h2>

--- a/blog/tags/libgdx/atom.xml
+++ b/blog/tags/libgdx/atom.xml
@@ -17,7 +17,7 @@
 <updated>2015-03-21T15:53:19+00:00</updated>
 <id>http://coconauts.net/blog/2015/03/21/exploding-bunnies</id>
 <content type="html"><![CDATA[<p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,

--- a/blog/tags/music/atom.xml
+++ b/blog/tags/music/atom.xml
@@ -223,7 +223,7 @@ future game.</p>
 <link href="http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects/"/>
 <updated>2015-07-06T20:10:17+00:00</updated>
 <id>http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects</id>
-<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
+<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
 which you might want to use in a game. But of course, if you are having
 8-bit music, you&rsquo;ll want your game sound effects to match as well.</p>
 
@@ -280,7 +280,7 @@ development.</p>
 <updated>2015-04-19T19:34:31+00:00</updated>
 <id>http://coconauts.net/blog/2015/04/19/creating-trve-chiptune-with-a-tracker</id>
 <content type="html"><![CDATA[<p>Following up with the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
 remember what I said about those purists only considering to be TRVE
 CHIPTUNE that in the format of Amiga MOD files created with an old
 school tracker software? Well, guess what, you can do just that to
@@ -323,7 +323,7 @@ of tutorials and documentation about all things chiptune and tracking.</li>
 
 
 <p>Don&rsquo;t forget though that there&rsquo;s a saner way to do it, we&rsquo;ve shown you how in the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
 ]]></content>
 </entry>
 

--- a/blog/tags/optimisation/atom.xml
+++ b/blog/tags/optimisation/atom.xml
@@ -16,7 +16,7 @@
 <link href="http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption/"/>
 <updated>2014-10-17T23:00:00+00:00</updated>
 <id>http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption</id>
-<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
+<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
 we explained the basics of the Arduino-Raspberry Pi comunication and we shared a simple code.</p>
 
 <p>But there is more, with a mix of hardware and software, we managed to reduce its power

--- a/blog/tags/radio/atom.xml
+++ b/blog/tags/radio/atom.xml
@@ -44,7 +44,7 @@ about how to use a generic 433Mhz radio module with an ESP8266  to control Energ
 <link href="http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption/"/>
 <updated>2014-10-17T23:00:00+00:00</updated>
 <id>http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption</id>
-<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
+<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
 we explained the basics of the Arduino-Raspberry Pi comunication and we shared a simple code.</p>
 
 <p>But there is more, with a mix of hardware and software, we managed to reduce its power

--- a/blog/tags/raspberry/atom.xml
+++ b/blog/tags/raspberry/atom.xml
@@ -71,7 +71,7 @@ controlled with a single Raspberry Pi.</p>
 <link href="http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption/"/>
 <updated>2014-10-17T23:00:00+00:00</updated>
 <id>http://coconauts.net/blog/2014/10/17/arduino-radio-improvements-low-consumption</id>
-<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
+<content type="html"><![CDATA[<p>In our previous post about how to <a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">send Readings From Arduino to a Raspberry Pi via radio</a>
 we explained the basics of the Arduino-Raspberry Pi comunication and we shared a simple code.</p>
 
 <p>But there is more, with a mix of hardware and software, we managed to reduce its power

--- a/blog/tags/smartwatch/atom.xml
+++ b/blog/tags/smartwatch/atom.xml
@@ -122,7 +122,7 @@ and I would like to share with you my impressions, its current features and its 
 <h2>Hardware</h2>
 
 <p>We need to talk about new hardware for Watchduino 2,
-as it is very different from its <a href="http://www.coconauts.net/projects/watchduino/">first version</a>
+as it is very different from its <a href="http://coconauts.net/projects/watchduino/">first version</a>
 which makes this new version smaller, prettier and more useful.</p>
 
 <ul>
@@ -141,7 +141,7 @@ which makes this new version smaller, prettier and more useful.</p>
 <h2>Features</h2>
 
 <p>Thanks to this new hardware, we managed to add new features to this new version.
-Most of them were mentioned in the <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
+Most of them were mentioned in the <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
 but you can have another look here:</p>
 
 <h3>Companion app (Android)</h3>

--- a/blog/tags/timebomb/atom.xml
+++ b/blog/tags/timebomb/atom.xml
@@ -16,7 +16,7 @@
 <link href="http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects/"/>
 <updated>2015-07-06T20:10:17+00:00</updated>
 <id>http://coconauts.net/blog/2015/07/06/easily-create-8-bit-sound-effects</id>
-<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
+<content type="html"><![CDATA[<p>In a past post we&rsquo;ve shown you <a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">how to make 8-bit music</a>,
 which you might want to use in a game. But of course, if you are having
 8-bit music, you&rsquo;ll want your game sound effects to match as well.</p>
 
@@ -73,7 +73,7 @@ development.</p>
 <updated>2015-04-19T19:34:31+00:00</updated>
 <id>http://coconauts.net/blog/2015/04/19/creating-trve-chiptune-with-a-tracker</id>
 <content type="html"><![CDATA[<p>Following up with the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post about chiptune music</a>,
 remember what I said about those purists only considering to be TRVE
 CHIPTUNE that in the format of Amiga MOD files created with an old
 school tracker software? Well, guess what, you can do just that to
@@ -116,7 +116,7 @@ of tutorials and documentation about all things chiptune and tracking.</li>
 
 
 <p>Don&rsquo;t forget though that there&rsquo;s a saner way to do it, we&rsquo;ve shown you how in the
-<a href="https://www.coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
+<a href="https://coconauts.net/blog/2015/02/02/creating-chiptune-style-music-with-ubuntu/">previous post</a>!</p>
 ]]></content>
 </entry>
 
@@ -126,7 +126,7 @@ of tutorials and documentation about all things chiptune and tracking.</li>
 <updated>2015-03-21T15:53:19+00:00</updated>
 <id>http://coconauts.net/blog/2015/03/21/exploding-bunnies</id>
 <content type="html"><![CDATA[<p>It&rsquo;s been half a year since
-<a href="http://www.coconauts.net/projects/timebomb2/">Super Time Bomb</a>
+<a href="http://coconauts.net/projects/timebomb2/">Super Time Bomb</a>
 was released. During this
 time, we&rsquo;ve been closely following it&rsquo;s reception, and gathering user
 feedback. Today we released an update with major gameplay changes,

--- a/blog/tags/uno/atom.xml
+++ b/blog/tags/uno/atom.xml
@@ -75,9 +75,9 @@ easily find compatible clonic boards on Amazon, Ebay or Aliexpress,
 at a fraction of the price.</p>
 
 <p>You could also use a bare ATMega328 like we did in our
-<a href="https://www.coconauts.net/projects/watchduino/">first Watchduino</a>
+<a href="https://coconauts.net/projects/watchduino/">first Watchduino</a>
 or in our
-<a href="https://www.coconauts.net/blog/2014/10/18/arduino-radio-improvements-low-consumption/">light sensor with RF24 radio module</a>.</p>
+<a href="https://coconauts.net/blog/2014/10/18/arduino-radio-improvements-low-consumption/">light sensor with RF24 radio module</a>.</p>
 
 <h2>Arduino UNO is big</h2>
 
@@ -126,7 +126,7 @@ will vary.</p>
 <p>Because it&rsquo;s big, and has a very high consumption, you shouldn&rsquo;t
 ever use it in a prototype, like a remote controlled device, or a
 batery-powered-sensor, or a
- <a href="https://www.coconauts.net/projects/watchduino2/">smartwatch</a>.</p>
+ <a href="https://coconauts.net/projects/watchduino2/">smartwatch</a>.</p>
 
 <p>Also, you probably don&rsquo;t want to develop in a hardware that won&rsquo;t
 match the final product specs, do you ?</p>

--- a/blog/tags/watchduino/atom.xml
+++ b/blog/tags/watchduino/atom.xml
@@ -206,7 +206,7 @@ Watchduino development!</p>
 <id>http://coconauts.net/blog/2015/08/24/watchduino-2-is-semifinalist-on-the-2015-hackaday-prize</id>
 <content type="html"><![CDATA[<p><img src="http://coconauts.net/images/posts/hackaday_semifinal.png" /></p>
 
-<p>We are really excited to announce that <a href="https://www.coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
+<p>We are really excited to announce that <a href="https://coconauts.net/projects/watchduino2/">WatchDuino 2</a> has passed to
 <a href="http://hackaday.com/2015/08/24/100-semifinalists-for-the-2015-hackaday-prize/">the semi-finals of the 2015 edition of the Hackaday Prize</a>!
 It was selected amongst the best 100 of a total of more than 900 projects.
 To see this kind of recognition out of a community that we admire is
@@ -245,7 +245,7 @@ and I would like to share with you my impressions, its current features and its 
 <h2>Hardware</h2>
 
 <p>We need to talk about new hardware for Watchduino 2,
-as it is very different from its <a href="http://www.coconauts.net/projects/watchduino/">first version</a>
+as it is very different from its <a href="http://coconauts.net/projects/watchduino/">first version</a>
 which makes this new version smaller, prettier and more useful.</p>
 
 <ul>
@@ -264,7 +264,7 @@ which makes this new version smaller, prettier and more useful.</p>
 <h2>Features</h2>
 
 <p>Thanks to this new hardware, we managed to add new features to this new version.
-Most of them were mentioned in the <a href="http://www.coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
+Most of them were mentioned in the <a href="http://coconauts.net/blog/2014/11/22/watchduino-2-dot-0-roadmap/">Watchduino roadmap post</a>,
 but you can have another look here:</p>
 
 <h3>Companion app (Android)</h3>

--- a/projects/dynamus/index.html
+++ b/projects/dynamus/index.html
@@ -119,7 +119,7 @@
 
 <ul>
 <li><a href="https://gitorious.org/dynamus">Source code</a></li>
-<li><a href="http://www.coconauts.net/mar/dynamus_thesis.pdf">Thesis document (in Spanish)</a></li>
+<li><a href="http://coconauts.net/mar/dynamus_thesis.pdf">Thesis document (in Spanish)</a></li>
 </ul>
 
 

--- a/projects/hardware/index.html
+++ b/projects/hardware/index.html
@@ -184,7 +184,7 @@ everytime a circuit is closed, or a button is pressed.</p>
 <h3>Related posts</h3>
 
 <ul>
-<li><a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">Send readings from arduino to android via Radio</a></li>
+<li><a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">Send readings from arduino to android via Radio</a></li>
 <li><a href="/blog/2014/10/18/arduino-radio-improvements-low-consumption/">Arduino and radio improvements</a></li>
 </ul>
 
@@ -201,7 +201,7 @@ with light levels at the room.</p>
 <h3>Related posts</h3>
 
 <ul>
-<li><a href="http://www.coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">Send readings from arduino to android via Radio</a></li>
+<li><a href="http://coconauts.net/blog/2014/09/03/send-readings-from-arduino-to-raspberry-via-radio/">Send readings from arduino to android via Radio</a></li>
 <li><a href="/blog/2014/10/18/arduino-radio-improvements-low-consumption/">Arduino and radio improvements</a></li>
 </ul>
 

--- a/projects/watchduino/index.html
+++ b/projects/watchduino/index.html
@@ -107,7 +107,7 @@ connectivity, and a better look and feel. Check it out! &hellip;">
   </header>
   
   <p>NOTE: We have a newer and sexier revision of Watchduino, including Bluetooth
-connectivity, and a better look and feel. <a href="https://www.coconauts.net/projects/watchduino2/">Check it out!</a></p>
+connectivity, and a better look and feel. <a href="https://coconauts.net/projects/watchduino2/">Check it out!</a></p>
 
 <iframe width="770" height="480" src="//www.youtube.com/embed/CtgR1YiwnEY" frameborder="0" allowfullscreen></iframe>
 

--- a/projects/watchduino2/index.html
+++ b/projects/watchduino2/index.html
@@ -107,7 +107,7 @@ Semifinalist in the &hellip;">
     
   </header>
   
-  <p>A smartwatch powered with Arduino, and a revision our previous <a href="http://www.coconauts.net/projects/watchduino/">Watchduino project</a>.</p>
+  <p>A smartwatch powered with Arduino, and a revision our previous <a href="http://coconauts.net/projects/watchduino/">Watchduino project</a>.</p>
 
 <p><img src='https://farm6.staticflickr.com/5717/21815509489_5531e2b080_z_d.jpg'/>
 <img src='https://farm1.staticflickr.com/772/22314247456_e69a4e1275_z_d.jpg'/></p>
@@ -125,7 +125,7 @@ Semifinalist in the &hellip;">
 
 <p>The Watchduino project started as an attempt to build a smartwatch at the reach of everyone: inexpensive and open. So that anyone can afford one, or even build it from scratch. And at the same time, so that anyone can built their custom applications for it.</p>
 
-<p>The <a href="http://www.coconauts.net/projects/watchduino/">first version of Watchduino</a> was a very simple standalone device that featured time, alarms, and a couple of games. You could say that it was really more like a traditional &ldquo;dumbwatch&rdquo;, except for the fact that the system was prepared to allow for custom user-programmed apps to be plugged in. On top of that, the total cost of the components to build one was around $10, and the battery life span was of months.</p>
+<p>The <a href="http://coconauts.net/projects/watchduino/">first version of Watchduino</a> was a very simple standalone device that featured time, alarms, and a couple of games. You could say that it was really more like a traditional &ldquo;dumbwatch&rdquo;, except for the fact that the system was prepared to allow for custom user-programmed apps to be plugged in. On top of that, the total cost of the components to build one was around $10, and the battery life span was of months.</p>
 
 <p>Since then, we&rsquo;ve been working on version 2, which we intend to be as fully featured as a regular commercial smartwatch. By including a BLE into the watch, we are able to pair the device with an Android phone, and send and make notifications flow between the two. It is still a work in progress, but we already have a prototype with some of the functionality, that we are ready to show the world.</p>
 


### PR DESCRIPTION
It seems every link that starts with `www.coconauts` is broken and some are corrected by removing the `www`.

Even so, this fix most links, there seems to be a lot of other broken links.